### PR TITLE
change underlying value of device and device file interface to pointer type

### DIFF
--- a/pkg/device/device_file.go
+++ b/pkg/device/device_file.go
@@ -64,22 +64,22 @@ func NewDeviceFile(path string) (DeviceFile, error) {
 	return &devFile, nil
 }
 
-func (d deviceFile) Path() string {
+func (d *deviceFile) Path() string {
 	return d.path
 }
 
-func (d deviceFile) Filename() string {
+func (d *deviceFile) Filename() string {
 	return filepath.Base(d.path)
 }
 
-func (d deviceFile) DeviceIndex() uint8 {
+func (d *deviceFile) DeviceIndex() uint8 {
 	return d.index
 }
 
-func (d deviceFile) CoreRange() CoreRange {
+func (d *deviceFile) CoreRange() CoreRange {
 	return &d.coreRange
 }
 
-func (d deviceFile) Mode() DeviceMode {
+func (d *deviceFile) Mode() DeviceMode {
 	return d.deviceMode
 }


### PR DESCRIPTION
Change underlying value of device and device file interface to Pointer Type from Value type to prohibit unexpected struct value copy.