### PR TITLE
change underlying value of device and device file interface to pointer type

### DIFF
--- a/pkg/device/device_file.go
+++ b/pkg/device/device_file.go
@@ -64,22 +64,22 @@ func NewDeviceFile(path string) (DeviceFile, error) {
 	return &devFile, nil
 }
 
-func (d deviceFile) Path() string {
+func (d *deviceFile) Path() string {
 	return d.path
 }
 
-func (d deviceFile) Filename() string {
+func (d *deviceFile) Filename() string {
 	return filepath.Base(d.path)
 }
 
-func (d deviceFile) DeviceIndex() uint8 {
+func (d *deviceFile) DeviceIndex() uint8 {
 	return d.index
 }
 
-func (d deviceFile) CoreRange() CoreRange {
+func (d *deviceFile) CoreRange() CoreRange {
 	return &d.coreRange
 }
 
-func (d deviceFile) Mode() DeviceMode {
+func (d *deviceFile) Mode() DeviceMode {
 	return d.deviceMode
 }


### PR DESCRIPTION
Change dynamic value type of device and device file interface from Value type to Pointer Type.

Interface has no concrete value type, the value type is inferred when something is assigned to interface variable. So...the dynamic value type of interface is determined by receiver definition of implementer.

Pointer type should be used to prohibit unexpected struct member copy when interface is passed as argument.

