### PR TITLE
Fix minor issue of manifest interface and warboy impl

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -7,9 +7,9 @@ type Manifest interface {
 	// https://github.com/kubernetes/kubernetes/pull/58172
 	Annotations() map[string]string
 	// DeviceNodes returns set of DeviceNode for dev file mount
-	DeviceNodes() []DeviceNode
+	DeviceNodes() []*DeviceNode
 	// MountPaths returns set of Mount for extra file and directory mount
-	MountPaths() []Mount
+	MountPaths() []*Mount
 }
 
 // Mount is subset of oci-runtime Mount spec

--- a/pkg/manifest/warboy.go
+++ b/pkg/manifest/warboy.go
@@ -43,11 +43,11 @@ func (w warboyManifest) Annotations() map[string]string {
 
 }
 
-func (w warboyManifest) DeviceNodes() []DeviceNode {
-	var deviceNodes []DeviceNode
+func (w warboyManifest) DeviceNodes() []*DeviceNode {
+	var deviceNodes []*DeviceNode
 
 	// mount npu mgmt file under "/dev"
-	deviceNodes = append(deviceNodes, DeviceNode{
+	deviceNodes = append(deviceNodes, &DeviceNode{
 		ContainerPath: devRoot + fmt.Sprintf(mgmtFileExp, w.device.Name()),
 		HostPath:      devRoot + fmt.Sprintf(mgmtFileExp, w.device.Name()),
 		Permissions:   readWriteOpt,
@@ -55,7 +55,7 @@ func (w warboyManifest) DeviceNodes() []DeviceNode {
 
 	// mount devFiles such as "/dev/npu0", "/dev/npu0pe0"
 	for _, file := range w.device.DevFiles() {
-		deviceNodes = append(deviceNodes, DeviceNode{
+		deviceNodes = append(deviceNodes, &DeviceNode{
 			ContainerPath: file.Path(),
 			HostPath:      file.Path(),
 			Permissions:   readWriteOpt,
@@ -64,7 +64,7 @@ func (w warboyManifest) DeviceNodes() []DeviceNode {
 
 	// mount channel fd for dma such as "/dev/npu0ch0" ~ "/dev/npu0ch3"
 	for idx := range iter.N(warboyMaxChannel) {
-		deviceNodes = append(deviceNodes, DeviceNode{
+		deviceNodes = append(deviceNodes, &DeviceNode{
 			ContainerPath: fmt.Sprintf(channelExp, w.device.Name(), idx),
 			HostPath:      fmt.Sprintf(channelExp, w.device.Name(), idx),
 			Permissions:   readWriteOpt,
@@ -74,12 +74,12 @@ func (w warboyManifest) DeviceNodes() []DeviceNode {
 	return deviceNodes
 }
 
-func (w warboyManifest) MountPaths() []Mount {
-	var mounts []Mount
+func (w warboyManifest) MountPaths() []*Mount {
+	var mounts []*Mount
 	devName := w.device.Name()
 
 	// mount "/sys/class/npu_mgmt/npu{x}_mgmt" path
-	mounts = append(mounts, Mount{
+	mounts = append(mounts, &Mount{
 		ContainerPath: sysClassRoot + fmt.Sprintf(mgmtFileExp, devName),
 		HostPath:      sysClassRoot + fmt.Sprintf(mgmtFileExp, devName),
 		Options:       []string{readOnlyOpt},
@@ -87,7 +87,7 @@ func (w warboyManifest) MountPaths() []Mount {
 
 	// mount all dev files under "/sys/class/npu_mgmt/"
 	for _, file := range w.device.DevFiles() {
-		mounts = append(mounts, Mount{
+		mounts = append(mounts, &Mount{
 			ContainerPath: sysClassRoot + file.Filename(),
 			HostPath:      sysClassRoot + file.Filename(),
 			Options:       []string{readOnlyOpt},
@@ -95,7 +95,7 @@ func (w warboyManifest) MountPaths() []Mount {
 	}
 
 	// mount "/sys/devices/virtual/npu_mgmt/npu{x}_mgmt" path
-	mounts = append(mounts, Mount{
+	mounts = append(mounts, &Mount{
 		ContainerPath: sysDevicesRoot + fmt.Sprintf(mgmtFileExp, devName),
 		HostPath:      sysDevicesRoot + fmt.Sprintf(mgmtFileExp, devName),
 		Options:       []string{readOnlyOpt},
@@ -103,7 +103,7 @@ func (w warboyManifest) MountPaths() []Mount {
 
 	// mount all dev files under "/sys/devices/virtual/npu_mgmt/"
 	for _, file := range w.device.DevFiles() {
-		mounts = append(mounts, Mount{
+		mounts = append(mounts, &Mount{
 			ContainerPath: sysDevicesRoot + file.Filename(),
 			HostPath:      sysDevicesRoot + file.Filename(),
 			Options:       []string{readOnlyOpt},

--- a/pkg/manifest/warboy_test.go
+++ b/pkg/manifest/warboy_test.go
@@ -28,11 +28,11 @@ func newTestWarboyDevice() device.Device {
 func TestDeviceNodes(t *testing.T) {
 	tests := []struct {
 		description         string
-		expectedDeviceNodes []DeviceNode
+		expectedDeviceNodes []*DeviceNode
 	}{
 		{
 			description: "test DeviceNodes()",
-			expectedDeviceNodes: []DeviceNode{
+			expectedDeviceNodes: []*DeviceNode{
 				{
 					ContainerPath: devRoot + fmt.Sprintf(mgmtFileExp, "npu0"),
 					HostPath:      devRoot + fmt.Sprintf(mgmtFileExp, "npu0"),
@@ -79,7 +79,6 @@ func TestDeviceNodes(t *testing.T) {
 		if !reflect.DeepEqual(actualDeviceNodes, tc.expectedDeviceNodes) {
 			t.Errorf("expected %v but got %v", tc.expectedDeviceNodes, actualDeviceNodes)
 		}
-
 	}
 
 }
@@ -87,11 +86,11 @@ func TestDeviceNodes(t *testing.T) {
 func TestMountPaths(t *testing.T) {
 	tests := []struct {
 		description        string
-		expectedMountPaths []Mount
+		expectedMountPaths []*Mount
 	}{
 		{
 			description: "test MountPaths()",
-			expectedMountPaths: []Mount{
+			expectedMountPaths: []*Mount{
 				{
 					ContainerPath: sysClassRoot + fmt.Sprintf(mgmtFileExp, "npu0"),
 					HostPath:      sysClassRoot + fmt.Sprintf(mgmtFileExp, "npu0"),


### PR DESCRIPTION
Change history
- 805af9d592ebdd901ceb2fe5ead6ae3d009d63ea(make DeviceNode permissions field public) : the field permissions of DeviceNode struct was supposed to be public.
- b44aa9e7ad69811953f21a5a9baa3bcef666169d(change the return type slice of struct to slice of pointer to struct for efficient memory usage): to avoid unnecessary struct copy.