### PR TITLE
fix not to install cargo-make

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           cd furiosa-smi
           rustup component add clippy rustfmt
-          cargo install --force cargo-make
           cargo build
           make install
       - uses: actions/checkout@v4


### PR DESCRIPTION
Due to unused module in github workflow, cargo-make, compilation error occurs during installing it.

Fix it not to install anymore.