### PR TITLE
Bump up Rust version to `nightly-2024-09-01`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,6 @@ RUN set -eux; \
     chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup --version; \
-    cargo --version; \
-    rustc --version;
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
 WORKDIR $GOPATH


### PR DESCRIPTION
### One line PR Description
Bump up Rust version to `nightly-2024-09-01`

### What type of PR is this?
/kind devops

### Special notes for reviewer
- `rustup` installation command has been changed to [follow the contents of the latest Rust `Dockerfile`](https://github.com/rust-lang/docker-rust/blob/master/1.80.1/bookworm/Dockerfile#L28-L30).
    - `rustup --version;`
    - `cargo --version;`
    - `rustc --version;`