### PR TITLE
Support multi-arch container image build (amd64 + arm64)

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -5,13 +5,24 @@ on:
     tags:
       - '*'
 
+env:
+  REGISTRY_URL: "asia-northeast3-docker.pkg.dev"
+  REGISTRY_PATH: "next-gen-infra/furiosa-ai"
+  IMAGE_NAME: "libfuriosa-kubernetes"
+
 jobs:
-  public_build_push:
-    runs-on: ubuntu-24.04
-    env:
-      REGISTRY_URL: "asia-northeast3-docker.pkg.dev"
-      REGISTRY_PATH: "next-gen-infra/furiosa-ai"
-      IMAGE_NAME: "libfuriosa-kubernetes"
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
 
@@ -24,10 +35,56 @@ jobs:
           username: "_json_key"
           password: ${{ secrets.GAR_JSON_KEY }}
 
-      - name: Build and publish a image with release tag
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          push: true
-          tags: '${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}'
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs: [build]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: public registry login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: "_json_key"
+          password: ${{ secrets.GAR_JSON_KEY }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
+            $(printf '${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_PATH }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:2026.1.1
+ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:244537c-test
 FROM $BASE_IMAGE as smi
 ARG TARGETARCH
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,28 @@
 ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:2026.1.1
 FROM $BASE_IMAGE as smi
+ARG TARGETARCH
+RUN set -eux; \
+    case "$TARGETARCH" in \
+        amd64) libDir='x86_64-linux-gnu' ;; \
+        arm64) libDir='aarch64-linux-gnu' ;; \
+        *) echo >&2 "unsupported architecture: $TARGETARCH"; exit 1 ;; \
+    esac; \
+    cp /usr/lib/$libDir/libfuriosa_smi.so /tmp/libfuriosa_smi.so
 
 FROM golang:1.25.4-bookworm
+ARG TARGETARCH
 
 # Copy hwloc binaries and libraries from the builder stage
-COPY --from=smi /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so
+COPY --from=smi /tmp/libfuriosa_smi.so /tmp/libfuriosa_smi.so
 COPY --from=smi /usr/include/furiosa/furiosa_smi.h /usr/include/furiosa/furiosa_smi.h
-RUN ldconfig
+RUN set -eux; \
+    case "$TARGETARCH" in \
+        amd64) libDir='x86_64-linux-gnu' ;; \
+        arm64) libDir='aarch64-linux-gnu' ;; \
+        *) echo >&2 "unsupported architecture: $TARGETARCH"; exit 1 ;; \
+    esac; \
+    mv /tmp/libfuriosa_smi.so /usr/lib/$libDir/libfuriosa_smi.so; \
+    ldconfig
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:2026.1.1
+ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:v2026.1.1
 FROM $BASE_IMAGE as smi
 ARG TARGETARCH
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:244537c-test
+ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:2026.1.1
 FROM $BASE_IMAGE as smi
 ARG TARGETARCH
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:v2026.1.1
 FROM $BASE_IMAGE as smi
 ARG TARGETARCH
-RUN set -eux; \
+RUN set -e; \
     case "$TARGETARCH" in \
         amd64) libDir='x86_64-linux-gnu' ;; \
         arm64) libDir='aarch64-linux-gnu' ;; \
@@ -15,7 +15,7 @@ ARG TARGETARCH
 # Copy hwloc binaries and libraries from the builder stage
 COPY --from=smi /tmp/libfuriosa_smi.so /tmp/libfuriosa_smi.so
 COPY --from=smi /usr/include/furiosa/furiosa_smi.h /usr/include/furiosa/furiosa_smi.h
-RUN set -eux; \
+RUN set -e; \
     case "$TARGETARCH" in \
         amd64) libDir='x86_64-linux-gnu' ;; \
         arm64) libDir='aarch64-linux-gnu' ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:v2026.1.1
+ARG BASE_IMAGE=asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-smi:2026.1.1
 FROM $BASE_IMAGE as smi
 ARG TARGETARCH
 RUN set -e; \


### PR DESCRIPTION
### One line PR Description
- resolve: CN-276

Build and publish the `libfuriosa-kubernetes` image for both `linux/amd64` and `linux/arm64`.
- Dockerfile: select the GNU multiarch lib dir from `TARGETARCH` instead of the hardcoded `x86_64-linux-gnu` path, so the library installs to the correct location on each architecture.
- CI: replace the single-arch build with a native-runner matrix (`ubuntu-24.04` + `ubuntu-24.04-arm`) that pushes each arch by digest, then a merge job assembles the multi-arch manifest via buildx imagetools.

### What type of PR is this?
/kind devops

### Special notes for reviewer
